### PR TITLE
Update socket connection for status display

### DIFF
--- a/frontend/src/pages/doctor/DocChatPage.tsx
+++ b/frontend/src/pages/doctor/DocChatPage.tsx
@@ -10,7 +10,6 @@ import {
 } from "../../services/chatServices";
 import { useSocket } from "../../context/SocketContext";
 import type { ChatMessage, Conversation } from "../../types/chat";
-import SocketStatus from "../../components/common/SocketStatus";
 
 interface User {
   id: string;
@@ -275,7 +274,6 @@ const DocChatPage: React.FC = () => {
 
   return (
     <div className="flex h-screen bg-gray-100">
-      <SocketStatus />
       {/* LEFT SIDEBAR - User Profile */}
       <div className="w-80 h-full flex flex-col items-center justify-center text-center px-4 bg-white border-r border-gray-200 p-6 shadow-md">
         <img
@@ -318,37 +316,23 @@ const DocChatPage: React.FC = () => {
                   </p>
                 </div>
               </div>
-              <div className="flex items-center space-x-2">
-                <button className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors">
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
-                    />
-                  </svg>
-                </button>
-                <button className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors">
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
-                    />
-                  </svg>
-                </button>
+              {/* Socket Connection Status */}
+              <div className="flex items-center space-x-3 bg-gray-50 rounded-lg px-3 py-2">
+                <div className="flex items-center space-x-2">
+                  <div 
+                    className={`w-3 h-3 rounded-full ${
+                      isConnected ? 'bg-green-500' : 'bg-red-500'
+                    }`}
+                  />
+                  <span className="text-sm font-medium text-gray-700">
+                    {isConnected ? 'Connected' : 'Disconnected'}
+                  </span>
+                </div>
+                {socket && isConnected && (
+                  <span className="text-xs text-gray-500">
+                    ID: {socket.id?.substring(0, 8)}...
+                  </span>
+                )}
               </div>
             </div>
 

--- a/frontend/src/pages/user/ChatPage.tsx
+++ b/frontend/src/pages/user/ChatPage.tsx
@@ -10,7 +10,6 @@ import {
 } from "../../services/chatServices";
 import { useSocket } from "../../context/SocketContext";
 import type { ChatMessage, Conversation } from "../../types/chat";
-import SocketStatus from "../../components/common/SocketStatus";
 
 interface Doctor {
   id: string;
@@ -317,7 +316,6 @@ const ChatPage: React.FC = () => {
 
   return (
     <div className="flex h-screen bg-gray-100">
-      <SocketStatus />
       {/* LEFT SIDEBAR - Doctor Profile */}
       <div className="w-80 h-full flex flex-col items-center justify-center text-center px-4 bg-white border-r border-gray-200 p-6 shadow-md">
         <img
@@ -360,37 +358,23 @@ const ChatPage: React.FC = () => {
                   </p>
                 </div>
               </div>
-              <div className="flex items-center space-x-2">
-                <button className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors">
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
-                    />
-                  </svg>
-                </button>
-                <button className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors">
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
-                    />
-                  </svg>
-                </button>
+              {/* Socket Connection Status */}
+              <div className="flex items-center space-x-3 bg-gray-50 rounded-lg px-3 py-2">
+                <div className="flex items-center space-x-2">
+                  <div 
+                    className={`w-3 h-3 rounded-full ${
+                      isConnected ? 'bg-green-500' : 'bg-red-500'
+                    }`}
+                  />
+                  <span className="text-sm font-medium text-gray-700">
+                    {isConnected ? 'Connected' : 'Disconnected'}
+                  </span>
+                </div>
+                {socket && isConnected && (
+                  <span className="text-xs text-gray-500">
+                    ID: {socket.id?.substring(0, 8)}...
+                  </span>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
Replaced audio/video call buttons with an inline socket connection status display in chat pages to show real-time connectivity.

---
<a href="https://cursor.com/background-agent?bcId=bc-7be9802e-fe31-4a10-844f-9e052ce57e20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7be9802e-fe31-4a10-844f-9e052ce57e20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

