### PR TITLE
Fix admin access denied errors

### DIFF
--- a/frontend/src/components/admin/AdminProtectedRoute.tsx
+++ b/frontend/src/components/admin/AdminProtectedRoute.tsx
@@ -1,0 +1,47 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { AdminContext } from "../../context/AdminContext";
+
+interface AdminProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+const AdminProtectedRoute: React.FC<AdminProtectedRouteProps> = ({ children }) => {
+  const context = useContext(AdminContext);
+  const [isLoading, setIsLoading] = useState(true);
+
+  if (!context) {
+    throw new Error("AdminContext must be used within AdminContextProvider");
+  }
+
+  const { aToken, loading } = context;
+
+  useEffect(() => {
+    // Wait for the admin context to finish loading
+    if (!loading) {
+      setIsLoading(false);
+    }
+  }, [loading]);
+
+  // Show loading while checking authentication
+  if (isLoading || loading) {
+    return (
+      <div className="flex h-screen bg-gray-100 items-center justify-center">
+        <div className="bg-white rounded-2xl shadow-xl p-8">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="text-gray-600 mt-4 text-center">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Redirect to admin login if no admin token
+  if (!aToken) {
+    return <Navigate to="/admin/login" replace />;
+  }
+
+  // Render children if authenticated
+  return <>{children}</>;
+};
+
+export default AdminProtectedRoute;

--- a/frontend/src/context/tokenManagerAdmin.ts
+++ b/frontend/src/context/tokenManagerAdmin.ts
@@ -1,10 +1,13 @@
 const ADMIN_ACCESS_TOKEN_KEY = 'adminAccessToken';
 
 export const getAdminAccessToken = () => {
-  return localStorage.getItem(ADMIN_ACCESS_TOKEN_KEY);
+  const token = localStorage.getItem(ADMIN_ACCESS_TOKEN_KEY);
+  console.log("TokenManagerAdmin: Getting admin token:", token ? "Present" : "Not present");
+  return token;
 };
 
 export const updateAdminAccessToken = (token: string | null) => {
+  console.log("TokenManagerAdmin: Updating admin token:", token ? "Set" : "Cleared");
   if (token) {
     localStorage.setItem(ADMIN_ACCESS_TOKEN_KEY, token);
   } else {
@@ -13,5 +16,6 @@ export const updateAdminAccessToken = (token: string | null) => {
 };
 
 export const clearAdminAccessToken = () => {
+  console.log("TokenManagerAdmin: Clearing admin token");
   localStorage.removeItem(ADMIN_ACCESS_TOKEN_KEY);
 };

--- a/frontend/src/pages/admin/AdminAppointments.tsx
+++ b/frontend/src/pages/admin/AdminAppointments.tsx
@@ -34,11 +34,7 @@ const AdminAppointments = () => {
     }
   }, [aToken, currentPage]);
 
-  useEffect(() => {
-    if (!aToken) {
-      navigate("/admin/login");
-    }
-  }, [aToken, navigate]);
+  // Token check is now handled by AdminProtectedRoute
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/frontend/src/pages/admin/AdminUsersList.tsx
+++ b/frontend/src/pages/admin/AdminUsersList.tsx
@@ -31,11 +31,7 @@ const AdminUsersList = () => {
     }
   }, [aToken, currentPage]);
 
-  useEffect(() => {
-    if (!aToken) {
-      navigate("/admin/login");
-    }
-  }, [aToken, navigate]);
+  // Token check is now handled by AdminProtectedRoute
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/frontend/src/routes/AdminRoutes.tsx
+++ b/frontend/src/routes/AdminRoutes.tsx
@@ -2,6 +2,7 @@ import { Route } from "react-router-dom";
 
 // Layout
 import AdminLayout from "../layouts/AdminLayout";
+import AdminProtectedRoute from "../components/admin/AdminProtectedRoute";
 
 // Admin Pages
 import AdminLogin from "../pages/admin/AdminLogin";
@@ -22,57 +23,71 @@ const AdminRoutes = () => {
       <Route
         path="/admin/dashboard"
         element={
-          <AdminLayout>
-            <AdminDashboard />
-          </AdminLayout>
+          <AdminProtectedRoute>
+            <AdminLayout>
+              <AdminDashboard />
+            </AdminLayout>
+          </AdminProtectedRoute>
         }
       />
       <Route
         path="/admin/user-management"
         element={
-          <AdminLayout>
-            <AdminUsersList />
-          </AdminLayout>
+          <AdminProtectedRoute>
+            <AdminLayout>
+              <AdminUsersList />
+            </AdminLayout>
+          </AdminProtectedRoute>
         }
       />
       <Route
         path="/admin/appointments"
         element={
-          <AdminLayout>
-            <AdminAppointments />
-          </AdminLayout>
+          <AdminProtectedRoute>
+            <AdminLayout>
+              <AdminAppointments />
+            </AdminLayout>
+          </AdminProtectedRoute>
         }
       />
       <Route
         path="/admin/doctor-requests"
         element={
-          <AdminLayout>
-            <AdminDoctorRequests />
-          </AdminLayout>
+          <AdminProtectedRoute>
+            <AdminLayout>
+              <AdminDoctorRequests />
+            </AdminLayout>
+          </AdminProtectedRoute>
         }
       />
       <Route
         path="/admin/update-doctor"
         element={
-          <AdminLayout>
-            <AdminUpdateDoctor />
-          </AdminLayout>
+          <AdminProtectedRoute>
+            <AdminLayout>
+              <AdminUpdateDoctor />
+            </AdminLayout>
+          </AdminProtectedRoute>
         }
       />
       <Route
         path="/admin/all-doctors"
         element={
-          <AdminLayout>
-            <AdminDoctorList />
-          </AdminLayout>
+          <AdminProtectedRoute>
+            <AdminLayout>
+              <AdminDoctorList />
+            </AdminLayout>
+          </AdminProtectedRoute>
         }
       />
       <Route
         path="/admin/inbox"
         element={
-          <AdminLayout>
-            <AdminInbox />
-          </AdminLayout>
+          <AdminProtectedRoute>
+            <AdminLayout>
+              <AdminInbox />
+            </AdminLayout>
+          </AdminProtectedRoute>
         }
       />
     </>


### PR DESCRIPTION
Implement admin protected routes to prevent unauthorized access and 403 errors by ensuring only valid admin tokens can access admin pages.

The previous setup allowed users with doctor tokens to access admin URLs, leading to components mounting and making API calls that resulted in 403 Forbidden errors before any redirection could occur. This change introduces a route-level guard that checks for a valid admin token *before* rendering any admin component, ensuring proper authentication and preventing erroneous API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-152f0b0e-419b-452e-be94-cd57d768c3a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-152f0b0e-419b-452e-be94-cd57d768c3a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

