### PR TITLE
Fix string to attachment type in doctorchat

### DIFF
--- a/frontend/src/pages/doctor/DocChatPage.tsx
+++ b/frontend/src/pages/doctor/DocChatPage.tsx
@@ -11,6 +11,7 @@ import {
 import { useSocket } from "../../context/SocketContext";
 import type { ChatMessage, Conversation } from "../../types/chat";
 import SocketStatus from "../../components/common/SocketStatus";
+import { createAttachmentFromUrl } from "../../utils/attachmentUtils";
 
 interface User {
   id: string;

--- a/frontend/src/types/chat.d.ts
+++ b/frontend/src/types/chat.d.ts
@@ -1,3 +1,15 @@
+export interface Attachment {
+  type: 'image' | 'file' | 'video' | 'audio' | 'url';
+  asset_url?: string;
+  image_url?: string;
+  file_url?: string;
+  thumb_url?: string;
+  title?: string;
+  name?: string;
+  size?: number;
+  mime_type?: string;
+}
+
 export interface ChatMessage {
   id: string;
   conversationId: string;
@@ -7,7 +19,7 @@ export interface ChatMessage {
   messageType: "text" | "image" | "file";
   timestamp: Date;
   isRead: boolean;
-  attachments?: string[];
+  attachments?: string[] | Attachment[];
 }
 
 export interface Conversation {
@@ -41,5 +53,5 @@ export interface SendMessageRequest {
   conversationId: string;
   message: string;
   messageType?: "text" | "image" | "file";
-  attachments?: string[];
+  attachments?: string[] | Attachment[];
 } 

--- a/frontend/src/utils/README.md
+++ b/frontend/src/utils/README.md
@@ -1,0 +1,141 @@
+# Attachment Utilities
+
+This module provides utility functions to handle URL-to-Attachment type conversions, particularly useful when working with chat systems that require properly formatted attachment objects instead of plain URL strings.
+
+## Problem
+
+When working with TypeScript and chat libraries (like stream-chat), you might encounter errors like:
+```
+Type 'string' is not assignable to type 'Attachment'.ts(2322)
+(parameter) url: string
+```
+
+This happens when you try to pass a URL string directly to a function that expects an Attachment object.
+
+## Solution
+
+Use the provided utility functions to convert URL strings to properly formatted Attachment objects.
+
+## Usage Examples
+
+### Basic URL to Attachment Conversion
+
+```typescript
+import { createAttachmentFromUrl } from './attachmentUtils';
+
+// Convert a simple URL string to an attachment
+const imageUrl = "https://example.com/image.jpg";
+const attachment = createAttachmentFromUrl(imageUrl, 'image');
+
+// Result:
+// {
+//   type: 'image',
+//   asset_url: 'https://example.com/image.jpg',
+//   image_url: 'https://example.com/image.jpg'
+// }
+```
+
+### Multiple URLs to Attachments
+
+```typescript
+import { createAttachmentsFromUrls } from './attachmentUtils';
+
+const urls = [
+  "https://example.com/file1.pdf",
+  "https://example.com/file2.docx"
+];
+
+const attachments = createAttachmentsFromUrls(urls, 'file');
+```
+
+### Auto-detect Attachment Type
+
+```typescript
+import { getAttachmentTypeFromUrl, createAttachmentFromUrl } from './attachmentUtils';
+
+const url = "https://example.com/video.mp4";
+const type = getAttachmentTypeFromUrl(url); // Returns 'video'
+const attachment = createAttachmentFromUrl(url, type);
+```
+
+### Validate URLs
+
+```typescript
+import { isValidUrl } from './attachmentUtils';
+
+const url = "https://example.com/file.pdf";
+if (isValidUrl(url)) {
+  // Proceed with attachment creation
+  const attachment = createAttachmentFromUrl(url);
+}
+```
+
+## Common Use Cases
+
+### In Chat Components
+
+```typescript
+// Before (causes TypeScript error):
+// sendMessage(conversationId, message, 'text', [url]); // Error!
+
+// After (works correctly):
+import { createAttachmentFromUrl } from '../utils/attachmentUtils';
+
+const attachment = createAttachmentFromUrl(url, 'image');
+sendMessage(conversationId, message, 'text', [attachment]);
+```
+
+### Processing File Uploads
+
+```typescript
+import { createAttachmentFromUrl, getAttachmentTypeFromUrl } from '../utils/attachmentUtils';
+
+const handleFileUpload = (uploadedFileUrl: string) => {
+  const type = getAttachmentTypeFromUrl(uploadedFileUrl);
+  const attachment = createAttachmentFromUrl(uploadedFileUrl, type, {
+    title: 'Uploaded File',
+    size: fileSize,
+    mime_type: fileMimeType
+  });
+  
+  // Now you can safely pass this to functions expecting Attachment objects
+  addAttachmentToMessage(attachment);
+};
+```
+
+## API Reference
+
+### `createAttachmentFromUrl(url, type?, additionalProps?)`
+Converts a URL string to an Attachment object.
+
+**Parameters:**
+- `url: string` - The URL to convert
+- `type?: AttachmentType` - Optional type ('image' | 'file' | 'video' | 'audio' | 'url'), defaults to 'file'
+- `additionalProps?: Partial<AttachmentObject>` - Optional additional properties
+
+**Returns:** `AttachmentObject`
+
+### `createAttachmentsFromUrls(urls, type?)`
+Converts an array of URL strings to Attachment objects.
+
+**Parameters:**
+- `urls: string[]` - Array of URLs to convert
+- `type?: AttachmentType` - Optional type for all attachments, defaults to 'file'
+
+**Returns:** `AttachmentObject[]`
+
+### `getAttachmentTypeFromUrl(url)`
+Auto-detects the attachment type based on file extension.
+
+**Parameters:**
+- `url: string` - The URL to analyze
+
+**Returns:** `AttachmentType`
+
+### `isValidUrl(url)`
+Validates if a string is a valid URL.
+
+**Parameters:**
+- `url: string` - String to validate
+
+**Returns:** `boolean`

--- a/frontend/src/utils/attachmentUtils.ts
+++ b/frontend/src/utils/attachmentUtils.ts
@@ -1,0 +1,101 @@
+// Utility functions for handling attachments and URL conversions
+
+export interface AttachmentObject {
+  type: 'image' | 'file' | 'video' | 'audio' | 'url';
+  asset_url?: string;
+  image_url?: string;
+  file_url?: string;
+  thumb_url?: string;
+  title?: string;
+  name?: string;
+  size?: number;
+  mime_type?: string;
+}
+
+/**
+ * Converts a URL string to a proper Attachment object
+ * @param url - The URL string to convert
+ * @param type - The type of attachment (default: 'file')
+ * @param additionalProps - Additional properties to include in the attachment
+ * @returns Properly formatted Attachment object
+ */
+export const createAttachmentFromUrl = (
+  url: string, 
+  type: AttachmentObject['type'] = 'file',
+  additionalProps: Partial<AttachmentObject> = {}
+): AttachmentObject => {
+  const baseAttachment: AttachmentObject = {
+    type,
+    asset_url: url,
+    ...additionalProps
+  };
+
+  // Add type-specific URL properties
+  switch (type) {
+    case 'image':
+      baseAttachment.image_url = url;
+      break;
+    case 'file':
+      baseAttachment.file_url = url;
+      break;
+    case 'video':
+      baseAttachment.asset_url = url;
+      break;
+    case 'audio':
+      baseAttachment.asset_url = url;
+      break;
+    case 'url':
+      baseAttachment.asset_url = url;
+      break;
+  }
+
+  return baseAttachment;
+};
+
+/**
+ * Converts an array of URL strings to an array of Attachment objects
+ * @param urls - Array of URL strings
+ * @param type - The type of attachments (default: 'file')
+ * @returns Array of Attachment objects
+ */
+export const createAttachmentsFromUrls = (
+  urls: string[], 
+  type: AttachmentObject['type'] = 'file'
+): AttachmentObject[] => {
+  return urls.map(url => createAttachmentFromUrl(url, type));
+};
+
+/**
+ * Validates if a string is a valid URL
+ * @param url - String to validate
+ * @returns boolean indicating if the string is a valid URL
+ */
+export const isValidUrl = (url: string): boolean => {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Gets the file type from a URL based on its extension
+ * @param url - The URL to analyze
+ * @returns The detected attachment type
+ */
+export const getAttachmentTypeFromUrl = (url: string): AttachmentObject['type'] => {
+  const extension = url.split('.').pop()?.toLowerCase();
+  
+  const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'];
+  const videoExtensions = ['mp4', 'webm', 'mov', 'avi', 'mkv'];
+  const audioExtensions = ['mp3', 'wav', 'ogg', 'aac', 'm4a'];
+  
+  if (extension) {
+    if (imageExtensions.includes(extension)) return 'image';
+    if (videoExtensions.includes(extension)) return 'video';
+    if (audioExtensions.includes(extension)) return 'audio';
+  }
+  
+  return 'file';
+};


### PR DESCRIPTION
Fixes 'string is not assignable to Attachment' TypeScript error by introducing attachment utility functions and updating chat type definitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c54e465-a56d-413a-9540-4b8cce9ec133">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c54e465-a56d-413a-9540-4b8cce9ec133">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

